### PR TITLE
Added ellipsis to overflow hidden text

### DIFF
--- a/scss/layout/_section.scss
+++ b/scss/layout/_section.scss
@@ -44,21 +44,31 @@ main {
 
     &__text {
         width: 100%;
-        overflow-x: hidden;
-        white-space: nowrap;
 
         &--primary { 
             font-weight: $fw-medium;
             font-size: 115%;
             margin-top: 5%;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            overflow-x: hidden;
 
             &:hover {
                 overflow-x: scroll;
+                text-overflow: initial;
             }
         }
         &--secondary {
             font-size: 80%;
             margin-top: 2%;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            overflow-x: hidden;
+
+            &:hover {
+                overflow-x: scroll;
+                text-overflow: initial;
+            }
         }
     }
 


### PR DESCRIPTION
Added ellipsis (...) to text that gets clipped / hidden after overflowing it's parent container.
On hover, users are shown a scrollbar which allows the viewing of the full text.

**Before**
<img width="656" alt="screenshot 2019-01-25 at 1 09 35 pm" src="https://user-images.githubusercontent.com/13101744/51746035-1b3a2980-20a5-11e9-8966-84a817750fbe.png">

**After**
<img width="656" alt="screenshot 2019-01-25 at 1 20 46 pm" src="https://user-images.githubusercontent.com/13101744/51746049-27be8200-20a5-11e9-9956-74b6b1e7d7d2.png">
