### PR TITLE
Feature/mobile download

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
     <link rel="stylesheet" type="text/css" media="screen" href="css/main.css" />
     <script src="/js/imageLoad.js" defer></script>
     <script src="/js/search.js" defer></script>
+    <script src="/js/mobileDownload.js" defer></script>
 </head>
 <body>
     <header>

--- a/js/mobileDownload.js
+++ b/js/mobileDownload.js
@@ -1,0 +1,15 @@
+window.addEventListener('load', ()=> {
+    const links = document.querySelectorAll('.logo__download__overlay a');
+    let clicks = 0; 
+    const stopLink = function (e) {
+        clicks ++;
+        // Prevent download on first clicks so as to enable hover effect on mobile
+        if (clicks % 2 !== 0) e.preventDefault();
+        
+    }
+    if (window.innerWidth < window.innerHeight) {
+        links.forEach(link => {
+            link.addEventListener('click', stopLink);
+        })
+    }
+})

--- a/js/mobileDownload.js
+++ b/js/mobileDownload.js
@@ -7,7 +7,7 @@ window.addEventListener('load', ()=> {
         if (clicks % 2 !== 0) e.preventDefault();
         
     }
-    if (window.innerWidth < window.innerHeight) {
+    if ('ontouchstart' in window || 'ontouch' in window) {
         links.forEach(link => {
             link.addEventListener('click', stopLink);
         })

--- a/scss/layout/_section.scss
+++ b/scss/layout/_section.scss
@@ -95,6 +95,7 @@ main {
             a{
                 color: inherit;
                 transition: all .5s ease-in-out;
+                font-size: 100%;
 
                 &:hover{ 
                     text-decoration: none;

--- a/scss/responsive/_section.scss
+++ b/scss/responsive/_section.scss
@@ -66,6 +66,6 @@
 
 @media screen and (max-width: 450px){
     body {
-        // font-size: 60%;
+        font-size: 60%;
     }
 }

--- a/scss/responsive/_section.scss
+++ b/scss/responsive/_section.scss
@@ -1,7 +1,15 @@
 @media screen and (max-width: 1215px){
     .logo {
-        width: 33.333333%; 
-    }
+        width: 33.333333%;
+    
+        &__download {
+            &__overlay {
+                a {
+                    font-size: 80%;
+                }
+            }
+        }
+    } 
 }
 
 @media screen and (max-width: 650px){
@@ -11,11 +19,53 @@
 
     .logo {
         width: 50%; 
+
+        &__download {
+            &__overlay {
+                a {
+                    font-size: 80%;
+                }
+            }
+        }
+    }
+}
+
+@media screen and (max-width: 500px){
+    .logo {
+        &__download {
+            &__overlay {
+                a {
+                    font-size: 70%;
+                }
+                &--svg, &--png {
+                    padding: 10%;
+
+                    &:hover {
+                        transform: scale(1);
+                    }
+                }
+            }
+        }
+    }
+}
+
+@media screen and (max-width: 350px){
+    .logo {
+        &__download {
+            &__overlay {
+                a {
+                    font-size: 65%;
+                }
+                &--svg, &--png {
+                    padding: 5% 2%;
+                }
+            }
+        }
     }
 }
 
 @media screen and (max-width: 450px){
     body {
-        font-size: 60%;
+        // font-size: 60%;
     }
 }


### PR DESCRIPTION
- Stopped download button from overflowing it's parent container on mobile

- Fixed automatic download on logo click caused by the lack of a hover effect to display download options on mobile

**Before**
<img width="377" alt="screenshot 2019-01-25 at 2 49 23 pm" src="https://user-images.githubusercontent.com/13101744/51755356-c1def400-20be-11e9-8e03-3b4541b81311.png">

**After**
<img width="379" alt="screenshot 2019-01-25 at 4 29 06 pm" src="https://user-images.githubusercontent.com/13101744/51755372-cb685c00-20be-11e9-980e-626ff333ac3d.png">


