### PR TITLE
Fix for Logos Appearing Small

### DIFF
--- a/scss/layout/_section.scss
+++ b/scss/layout/_section.scss
@@ -38,6 +38,10 @@ main {
         }
     }
 
+    &__image {
+        width: 100%;
+    }
+    
     &__image img {
         width: 70%;
     }


### PR DESCRIPTION
So I noticed the logos I pushed were appearing small.
After inspecting the CSS I discovered there's no width set for the **`logo__image`** tag; which is necessary to enable the logo SVGs scale appropriately to their maximum width i.e 100% _(though constrained by **`.logo__image img` - width: 70%**)_

_PS: This breaks nothing, all other logos look the same and doesn't affect responsiveness._