### PR TITLE
Fixed logos not displaying

### DIFF
--- a/js/logos.json
+++ b/js/logos.json
@@ -298,4 +298,4 @@
 	"title": "Quickteller",
 	"filename": "quickteller",
 	"category": "Banking / Financial Services"
-}];
+}]


### PR DESCRIPTION
Just after the last merge; All the logos were not displaying. 
_I believe this must have been caused by a merge on a conflict PR._
This fixes it and all should be fine.